### PR TITLE
Fix #53304 - trapdoor spider spawner crash

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -669,7 +669,7 @@
     "difficulty": 99,
     "trap_radius": 4,
     "action": "spell",
-    "spell_data": { "id": "Summon_trapspider" },
+    "spell_data": { "id": "summon_trapspider" },
     "always_invisible": true
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix trapdoor spider spawner crash"

#### Purpose of change
Fix #53304

#### Describe the solution
Fix capitalization error

#### Describe alternatives you've considered
...not fixing it?

#### Testing
Unable to reproduce bug, didn't test.

#### Additional context
This is the only place the error message's text appears in the entire repo.
